### PR TITLE
Improve release workflow with reusable workflow and better certificate handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,12 @@ on:
       tag_name:
         description: 'Tag name for release (e.g. v1.0.1)'
         required: true
+  workflow_call:
+    inputs:
+      tag_name:
+        description: 'Tag name for release'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -47,11 +53,17 @@ jobs:
 
       # macOS: 証明書をキーチェーンにインポート
       - name: Import Code Signing Certificate
-        if: matrix.platform == 'mac' && secrets.CSC_LINK != ''
+        if: matrix.platform == 'mac'
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
         run: |
+          # 証明書がない場合はスキップ
+          if [ -z "$CSC_LINK" ]; then
+            echo "No code signing certificate provided, skipping..."
+            exit 0
+          fi
+
           # 一時キーチェーンを作成
           KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
@@ -79,8 +91,8 @@ jobs:
           APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
           APPLE_ID_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_ID_PASSWORD || '' }}
           APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
-          # 証明書がある場合は明示的に自動検出を無効化し、それ以外では元の動作を維持
-          CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.platform == 'mac' && (secrets.CSC_LINK != '' && 'false' || 'true') || 'false' }}
+          # 証明書の自動検出を無効化（明示的に設定された証明書のみ使用）
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -125,7 +137,7 @@ jobs:
       - name: Upload assets to Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          tag_name: ${{ github.event.release.tag_name || inputs.tag_name || github.event.inputs.tag_name }}
           files: release-files/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -31,6 +31,34 @@ jobs:
         run: npm ci
 
       - name: Run semantic-release
+        id: semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        run: |
+          # semantic-releaseの出力をキャプチャ
+          npx semantic-release 2>&1 | tee release-output.txt
+
+          # リリースが作成されたか確認（新しいバージョンが公開された場合）
+          if grep -q "Published release" release-output.txt; then
+            echo "release_created=true" >> $GITHUB_OUTPUT
+          else
+            echo "release_created=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get latest tag
+        id: get-tag
+        if: steps.semantic-release.outputs.release_created == 'true'
+        run: |
+          # 最新のタグを取得
+          git fetch --tags
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          echo "tag_name=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "Latest tag: $LATEST_TAG"
+
+      - name: Trigger Release Build workflow
+        if: steps.semantic-release.outputs.release_created == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release.yml \
+            --field tag_name=${{ steps.get-tag.outputs.tag_name }}


### PR DESCRIPTION
## Summary
This PR enhances the CI/CD release pipeline by making the release workflow reusable and improving code signing certificate handling. It also adds automation to trigger release builds when semantic-release creates a new version.

## Key Changes

- **Made release workflow reusable**: Added `workflow_call` trigger to `release.yml` to allow other workflows to invoke it programmatically with a `tag_name` input parameter

- **Improved code signing certificate handling**: 
  - Changed the certificate import condition from a secrets check to always run, with runtime validation inside the script
  - Simplified `CSC_IDENTITY_AUTO_DISCOVERY` to always be `false`, ensuring only explicitly provided certificates are used
  - Added clear skip logic when no certificate is provided

- **Enhanced semantic-release workflow**:
  - Added output capture to detect when a release is actually created
  - Added step to extract the latest git tag after successful release
  - Added automatic trigger of the release build workflow when a new version is published
  - This creates a complete automation chain: semantic-release → tag creation → build workflow execution

- **Fixed tag_name resolution**: Updated the release upload step to check `inputs.tag_name` (for reusable workflow calls) before falling back to `github.event.inputs.tag_name`

## Implementation Details

The semantic-release workflow now:
1. Runs semantic-release and captures its output
2. Checks if a release was actually created (by looking for "Published release" in output)
3. If successful, fetches the latest tag and triggers the release build workflow with that tag
4. This eliminates manual intervention needed to build and publish artifacts after version bumping

The improved certificate handling makes the workflow more robust by validating certificate availability at runtime rather than at workflow parse time, allowing the workflow to gracefully skip signing when certificates aren't available.

https://claude.ai/code/session_01JT3x3oXcJ2AAYKk1EqhxGf