### PR TITLE
Remove notarize option from package.json to fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "entitlements": "assets/mac/entitlements.mac.plist",
-      "entitlementsInherit": "assets/mac/entitlements.mac.inherit.plist",
-      "notarize": true
+      "entitlementsInherit": "assets/mac/entitlements.mac.inherit.plist"
     },
     "win": {
       "icon": "assets/icons/icon.ico",


### PR DESCRIPTION
notarize: true causes build failures when Apple credentials are not configured. Notarization will be handled conditionally in the workflow when APPLE_ID, APPLE_ID_PASSWORD, and APPLE_TEAM_ID secrets are set.

https://claude.ai/code/session_01JT3x3oXcJ2AAYKk1EqhxGf